### PR TITLE
Add the silent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Type: `Boolean`
 
 Show debug information (options list and selected files), default to `false`.
 
+### silent
+
+Type: `Boolean`
+
+Don't throw an error in case of duplicated occurrences (useful for CI), default to `false`.
+
 # Tests
 
 Run tests using mocha

--- a/lib/gulp-jscpd.js
+++ b/lib/gulp-jscpd.js
@@ -26,7 +26,8 @@ module.exports = function(opts) {
     output      : null,
     path        : null,
     verbose     : false,
-    debug       : false
+    debug       : false,
+    silent      : false
   }, opts);
   opts = util._extend(opts, config);
   if (config.path) {
@@ -105,9 +106,11 @@ module.exports = function(opts) {
         map.getPercentage() + '% (' + map.numberOfDuplication + ' lines) ' +
         'duplicated lines out of ' + map.numberOfLines + ' total lines of code'
       );
-      this.emit('error', new gutil.PluginError('gulp-jscpd', output, {
-        showStack: false
-      }));
+      if(!opts.silent) {
+        this.emit('error', new gutil.PluginError('gulp-jscpd', output, {
+          showStack: false
+        }));
+      }
     }
 
     return cb();


### PR DESCRIPTION
We want to integrate jscpd into our CI pipeline, and it messes up our tests status when the plugin is throwing an error. Would be great if there was an option to mute the plugin's output :)