### PR TITLE
Provide xsl-href option to jscpd reporter

### DIFF
--- a/lib/gulp-jscpd.js
+++ b/lib/gulp-jscpd.js
@@ -35,7 +35,8 @@ module.exports = function(opts) {
   var report   = new Report({
     verbose: opts.verbose,
     output: opts.output,
-    reporter: opts.reporter
+    reporter: opts.reporter,
+    'xsl-href': opts['xsl-href']
   });
 
   if (opts.debug) {


### PR DESCRIPTION
The newly added `xsl-href` option was not provided to the jscpd Report.
