### PR TITLE
Allow to print the result without failing the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ Show debug information (options list and selected files), default to `false`.
 
 Type: `Boolean`
 
-Don't throw an error in case of duplicated occurrences (useful for CI), default to `false`.
+Don't print a report summary, default to `false`.
+
+### failOnError
+
+Type: `Boolean`
+
+Don't throw an error in case of duplicated occurrences (useful for CI), default to `true`.
 
 # Tests
 

--- a/lib/gulp-jscpd.js
+++ b/lib/gulp-jscpd.js
@@ -26,6 +26,7 @@ module.exports = function(opts) {
     verbose     : false,
     debug       : false,
     silent      : false,
+    failOnError : true,
     'xsl-href'  : null
   }, opts);
   opts = optionsPreprocessor({options: opts});
@@ -100,10 +101,19 @@ module.exports = function(opts) {
         map.getPercentage() + '% (' + map.numberOfDuplication + ' lines) ' +
         'duplicated lines out of ' + map.numberOfLines + ' total lines of code'
       );
+      if (typeof opts.output === 'string' && opts.output.length > 0) {
+        output += gutil.colors.red(
+          '\n\nThe full report can be found at: ' + path.resolve(opts.output)
+        );
+      }
       if (!opts.silent) {
-        this.emit('error', new gutil.PluginError('gulp-jscpd', output, {
-          showStack: false
-        }));
+        if (opts.failOnError) {
+          this.emit('error', new gutil.PluginError('gulp-jscpd', output, {
+            showStack: false
+          }));
+        } else {
+          gutil.log(output);
+        }
       }
     }
 


### PR DESCRIPTION
Adding an option `failOnError` (option name inspired by [gulp-eslint](https://github.com/adametry/gulp-eslint#eslintfailonerror)) in order to allow printing the result without failing the task if duplicities are found (which is the default when using `jscpd` from command line).
Related to #3.

PD: Also added the path of the output file if specified. Please let me know if you prefer to not include this or separate it in a different pull request.
